### PR TITLE
Abstract creation/deletion of comments

### DIFF
--- a/src/main/scala/pt/ulisboa/tecnico/socialsoftware/saslearning/domain/collaboration/Annotation.scala
+++ b/src/main/scala/pt/ulisboa/tecnico/socialsoftware/saslearning/domain/collaboration/Annotation.scala
@@ -5,30 +5,12 @@ import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.refined.types.numeric.{NonNegLong, PosLong}
 import pt.ulisboa.tecnico.socialsoftware.saslearning.domain.{User, WithId}
 
-import scala.collection.immutable.Seq
-
 case class Annotation(id: Option[Long],
                       position: NonNegLong, offset: PosLong, content: NonEmptyString,
                       creator: User,
-                      thread: Option[Thread] = None) extends WithId {
+                      thread: Option[Thread] = None) extends WithId with Post[Annotation] {
 
-  def post(comment: Comment): Either[String, Annotation] = {
-    val threadWithComment = thread match {
-      case Some(t) => t.add(comment)
-      case _ => Thread.fromUnsafe(Seq(comment))
-    }
-
-    threadWithComment.map(thread => this.copy(thread = Some(thread)))
-  }
-
-  def deletePost(comment: Comment): Annotation = {
-    val updatedAnnotation: Option[Annotation] = for {
-      concreteThread <- thread
-    } yield this.copy(thread = concreteThread.delete(comment).toOption)
-
-    updatedAnnotation.getOrElse(this)
-  }
-
+  override def updateThread(thread: Option[Thread]): Annotation = this.copy(thread = thread)
 }
 
 object Annotation {

--- a/src/main/scala/pt/ulisboa/tecnico/socialsoftware/saslearning/domain/collaboration/Post.scala
+++ b/src/main/scala/pt/ulisboa/tecnico/socialsoftware/saslearning/domain/collaboration/Post.scala
@@ -1,0 +1,19 @@
+package pt.ulisboa.tecnico.socialsoftware.saslearning.domain.collaboration
+import scala.collection.immutable.Seq
+
+trait Post[T] {
+  def thread: Option[Thread]
+
+  def updateThread(thread: Option[Thread]): T
+
+  def postComment(comment: Comment): Either[String, T] = {
+    val threadWithComment = thread match {
+      case Some(t) => t.add(comment)
+      case _ => Thread.fromUnsafe(Seq(comment))
+    }
+
+    threadWithComment.map(thread => updateThread(Some(thread)))
+  }
+
+  def deleteComment(comment: Comment): T = updateThread(thread.flatMap(_.delete(comment).toOption))
+}

--- a/src/test/scala/pt/ulisboa/tecnico/socialsoftware/saslearning/domain/collaboration/AnnotationSpec.scala
+++ b/src/test/scala/pt/ulisboa/tecnico/socialsoftware/saslearning/domain/collaboration/AnnotationSpec.scala
@@ -68,7 +68,7 @@ class AnnotationSpec extends WordSpec
   "Posting a comment" should {
     val question = Question("What is an annotation?", user)
     "create a thread when it doesn't exist" in {
-      val threadedAnnotation = defaultAnnotation.post(question)
+      val threadedAnnotation = defaultAnnotation.postComment(question)
 
       val expectedAnnotation = Thread
         .fromUnsafe(Seq(question))
@@ -83,7 +83,7 @@ class AnnotationSpec extends WordSpec
     "add it to the thread" in {
       val answer = Answer("An annotation is ...", user)
       val actualAnnotation = Thread.fromUnsafe(Seq(question)).flatMap { thread =>
-        Annotation(None, 0l, 1l, "This is an annotation", user, Some(thread)).post(answer)
+        Annotation(None, 0l, 1l, "This is an annotation", user, Some(thread)).postComment(answer)
       }
 
       val expectedAnnotation = Thread
@@ -109,7 +109,7 @@ class AnnotationSpec extends WordSpec
       }
 
       val actualAnnotation = Thread.fromUnsafe(Seq(question, answer)).map { thread =>
-        Annotation(None, 0l, 1l, "This is an annotation", user, Some(thread)).deletePost(answer)
+        Annotation(None, 0l, 1l, "This is an annotation", user, Some(thread)).deleteComment(answer)
       }
 
       expectedAnnotation.map { expected =>
@@ -117,8 +117,8 @@ class AnnotationSpec extends WordSpec
       }
     }
     "delete the thread" in {
-      defaultAnnotation.post(question).map { actual =>
-        assert(defaultAnnotation == actual.deletePost(question))
+      defaultAnnotation.postComment(question).map { actual =>
+        assert(defaultAnnotation == actual.deleteComment(question))
       }
     }
   }


### PR DESCRIPTION
This is useful since multiple classes can have comments (like `Annotation` and `Document`)